### PR TITLE
cached categories to omit frequent call

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -84,4 +84,8 @@ dependencies {
     implementation(libs.glide)
 
     implementation(libs.androidx.biometric)
+
+    implementation("androidx.room:room-runtime:2.7.2")
+    kapt("androidx.room:room-compiler:2.6.1")
+    implementation("androidx.room:room-ktx:2.7.2")
 }

--- a/app/src/main/java/com/teebay/appname/constants/PrefKeys.kt
+++ b/app/src/main/java/com/teebay/appname/constants/PrefKeys.kt
@@ -8,4 +8,5 @@ enum class PrefKeys {
     LNAME,
     ADDRESS,
     FCM,
+    LAST_SYNCED
 }

--- a/app/src/main/java/com/teebay/appname/db/AppDatabase.kt
+++ b/app/src/main/java/com/teebay/appname/db/AppDatabase.kt
@@ -1,0 +1,10 @@
+package com.teebay.appname.db
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import com.teebay.appname.features.myProduct.model.Category
+
+@Database(entities = [Category::class], version = 1)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun categoryDao(): CategoryDao
+}

--- a/app/src/main/java/com/teebay/appname/db/CategoryDao.kt
+++ b/app/src/main/java/com/teebay/appname/db/CategoryDao.kt
@@ -1,0 +1,19 @@
+package com.teebay.appname.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.teebay.appname.features.myProduct.model.Category
+
+@Dao
+interface CategoryDao {
+    @Query("SELECT * FROM categories")
+    suspend fun getAll(): List<Category>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(list: List<Category>)
+
+    @Query("DELETE FROM categories")
+    suspend fun clearAll()
+}

--- a/app/src/main/java/com/teebay/appname/di/DatabaseModule.kt
+++ b/app/src/main/java/com/teebay/appname/di/DatabaseModule.kt
@@ -1,0 +1,29 @@
+package com.teebay.appname.di
+
+import android.content.Context
+import androidx.room.Room
+import com.teebay.appname.db.AppDatabase
+import com.teebay.appname.db.CategoryDao
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+class DatabaseModule {
+    @Provides
+    @Singleton
+    fun provideDatabase(@ApplicationContext context: Context): AppDatabase {
+        return Room.databaseBuilder(
+            context,
+            AppDatabase::class.java,
+            "app_database"
+        ).build()
+    }
+
+    @Provides
+    fun provideCategoryDao(db: AppDatabase): CategoryDao = db.categoryDao()
+}

--- a/app/src/main/java/com/teebay/appname/features/myProduct/model/Category.kt
+++ b/app/src/main/java/com/teebay/appname/features/myProduct/model/Category.kt
@@ -1,7 +1,12 @@
 package com.teebay.appname.features.myProduct.model
 
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import java.util.Date
+
+@Entity(tableName = "categories")
 data class Category(
-    val label: String?,
+    @PrimaryKey val label: String?,
     val value: String?,
     var isSelected: Boolean = false
 )

--- a/app/src/main/java/com/teebay/appname/features/myProduct/repository/ProductRepository.kt
+++ b/app/src/main/java/com/teebay/appname/features/myProduct/repository/ProductRepository.kt
@@ -1,5 +1,7 @@
 package com.teebay.appname.features.myProduct.repository
 
+import com.teebay.appname.constants.PrefKeys
+import com.teebay.appname.db.CategoryDao
 import com.teebay.appname.features.allProduct.model.Product
 import com.teebay.appname.features.myProduct.model.AddProductRequestModel
 import com.teebay.appname.features.myProduct.model.AddProductResponseModel
@@ -12,12 +14,17 @@ import com.teebay.appname.features.productDetails.model.RentResponseModel
 import com.teebay.appname.network.EmptyResponseModel
 import com.teebay.appname.network.mapResult
 import com.teebay.appname.network.safeApiCall
+import com.teebay.appname.utils.SharedPref
+import com.teebay.appname.utils.isBeforeDate
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.toRequestBody
+import java.util.Date
 import javax.inject.Inject
 
 class ProductRepository @Inject constructor(
-    private val apiService: ProductApiService
+    private val apiService: ProductApiService,
+    private val dao: CategoryDao,
+    private val pref: SharedPref,
 ) {
     suspend fun postProduct(request: AddProductRequestModel): Result<AddProductResponseModel> {
         val seller =
@@ -51,8 +58,23 @@ class ProductRepository @Inject constructor(
         }
     }
 
-    suspend fun fetchCategories(): Result<List<Category>> =
-        safeApiCall { apiService.fetchCategories().mapResult() }
+    suspend fun fetchCategories(): Result<List<Category>> {
+        val lastSync = pref.get(PrefKeys.LAST_SYNCED.name) ?: ""
+        val needSync = isBeforeDate(lastSync, Date().toString())
+
+        if(needSync) {
+            val result = safeApiCall { apiService.fetchCategories().mapResult() }
+            if (result.isSuccess) {
+                result.getOrNull()?.let {
+                    dao.insertAll(it)
+                }
+            }
+            return result
+        } else {
+            val result = dao.getAll()
+            return Result.success(result)
+        }
+    }
 
     suspend fun fetchAllProducts(): Result<List<Product>> =
         safeApiCall { apiService.fetchAllProducts().mapResult() }

--- a/app/src/main/java/com/teebay/appname/utils/DateTimeUtil.kt
+++ b/app/src/main/java/com/teebay/appname/utils/DateTimeUtil.kt
@@ -37,3 +37,16 @@ fun isFromDateBeforeToDate(fromDate: String, toDate: String): Boolean {
     val to = format.parse(toDate) ?: return false
     return from.before(to)
 }
+
+fun isBeforeDate(fromDate: String, toDate: String): Boolean {
+    return try {
+        val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.getDefault()).apply {
+            timeZone = TimeZone.getTimeZone("UTC")
+        }
+        val from = format.parse(fromDate)
+        val to = format.parse(toDate)
+        from != null && to != null && from.before(to)
+    } catch (e: Exception) {
+        false
+    }
+}


### PR DESCRIPTION
It was supposed that, categories will be fixed for 3 months. After 3 months categories can be changed or diverse. So instead of calling every time in the product page we need to cache categories for 3 months a load data from cache